### PR TITLE
RK-356 Refactor Holiday Versions APIs

### DIFF
--- a/src/modules/common.ts
+++ b/src/modules/common.ts
@@ -2,7 +2,6 @@ import type { AxiosInstance } from "axios";
 
 export abstract class ApiGroup {
    protected axios: AxiosInstance
-
     constructor(axios: AxiosInstance) {
        this.axios = axios
     }

--- a/src/modules/holidayVersion.ts
+++ b/src/modules/holidayVersion.ts
@@ -1,6 +1,7 @@
 import type {AxiosInstance} from "axios";
-import type {IHoliday, UpdateHolidayInput} from "./holidays";
+import type {CreateHolidayInput, HolidayListQuery, IHoliday, UpdateHolidayInput} from "./holidays";
 import type {FieldData} from "./fields";
+import {ApiGroup, type Paginated} from "./common";
 
 
 export interface IHolidayVersion extends IHoliday {
@@ -42,4 +43,63 @@ export class HolidayVersion implements IHolidayVersion {
     get path(): string {
         return `/holidays/${this.holiday_id}/versions/${this.id}`
     }
+}
+
+
+export class HolidayVersions extends ApiGroup {
+
+    readonly holidayId: string
+
+    constructor(axios: AxiosInstance, holidayId: string) {
+        super(axios)
+        this.holidayId = holidayId
+    }
+
+    /**
+     * Get the versions for a `Holiday`
+     *
+     * @param params
+     */
+    async list(params?: HolidayListQuery): Promise<Paginated<HolidayVersion>> {
+        const response = (await this.axios.get<Paginated<IHolidayVersion>>(`/holidays/${this.holidayId}/versions`, { params })).data
+
+        response.data = response.data.map(v => new HolidayVersion(v, this.axios))
+
+        return response as Paginated<HolidayVersion>
+    }
+
+    /**
+     * Find a specific version
+     * @param id
+     */
+    async find(id: string): Promise<HolidayVersion> {
+        const response = (await this.axios.get<IHolidayVersion>(`/holidays/${this.holidayId}/versions/${id}`)).data
+        return new HolidayVersion(response, this.axios)
+    }
+
+    /**
+     * Create a new Version for this holiday
+     * @param params
+     */
+    async create(params: CreateHolidayInput): Promise<HolidayVersion> {
+        const response = (await this.axios.post<IHolidayVersion>(`/holidays/${this.holidayId}/versions`, params)).data
+        return new HolidayVersion(response, this.axios)
+    }
+
+    /**
+     * Restore a deleted Holiday Version
+     * @param id
+     */
+    async restore(id: string): Promise<HolidayVersion> {
+        const response = (await this.axios.put<HolidayVersion>(`/holidays/${this.holidayId}/versions/${id}/restore`)).data
+        return new HolidayVersion(response, this.axios)
+    }
+
+    /**
+     * Destroy a holiday version
+     */
+    async destroy(id: string): Promise<void> {
+        await this.axios.delete(`/holidays/${this.holidayId}/versions/${id}`)
+    }
+
 }

--- a/src/modules/holidays.ts
+++ b/src/modules/holidays.ts
@@ -9,7 +9,7 @@ import {
 } from "./common";
 import type {FieldData} from "./fields";
 import type {AxiosInstance} from "axios";
-import {HolidayVersion, type IHolidayVersion} from "./holidayVersion";
+import {HolidayVersion, HolidayVersions, type IHolidayVersion} from "./holidayVersion";
 
 export interface IHoliday extends Entity {
     name: string
@@ -88,47 +88,8 @@ export class Holiday implements IHoliday {
         return this
     }
 
-    /**
-     * Get the versions for a `Holiday`
-     *
-     * @param params
-     */
-    async versions(params?: HolidayListQuery): Promise<Paginated<HolidayVersion>> {
-        const response = (await this.axios.get<Paginated<IHolidayVersion>>(`/holidays/${this.id}/versions`, { params })).data
-
-        response.data = response.data.map(v => new HolidayVersion(v, this.axios))
-
-        return response as Paginated<HolidayVersion>
-    }
-
-    async version(id: string): Promise<HolidayVersion> {
-        const response = (await this.axios.get<IHolidayVersion>(`/holidays/${this.id}/versions/${id}`)).data
-        return new HolidayVersion(response, this.axios)
-    }
-
-    /**
-     * Create a new Version for this holiday
-     * @param params
-     */
-    async createVersion(params: CreateHolidayInput): Promise<HolidayVersion> {
-        const response = (await this.axios.post<IHolidayVersion>(`/holidays/${this.id}/versions`, params)).data
-        return new HolidayVersion(response, this.axios)
-    }
-
-    /**
-     * Restore a deleted Holiday Version
-     * @param id
-     */
-    async restoreVersion(id: string): Promise<HolidayVersion> {
-        const response = (await this.axios.put<HolidayVersion>(`/holidays/${this.id}/versions/${id}/restore`)).data
-        return new HolidayVersion(response, this.axios)
-    }
-    
-    /**
-     * Destroy a holiday version
-     */
-    async destroyVersion(id: string): Promise<void> {
-        await this.axios.delete(`/holidays/${this.id}/versions/${id}`)
+    get versions(): HolidayVersions {
+        return new HolidayVersions(this.axios, this.id)
     }
 
     code!: string;
@@ -243,5 +204,10 @@ export class Api extends ApiGroup {
     async restore(id: string): Promise<Holiday> {
         const { data } = await this.axios.put(`/holidays/${id}/restore`)
         return new Holiday(data, this.axios)
+    }
+
+    // Get a versions API client
+    versions(holidayId: string): HolidayVersions {
+        return new HolidayVersions(this.axios, holidayId)
     }
 }


### PR DESCRIPTION
This PR changes the interface for holiday versions to be more semantic.

Instead of having version management functions directly on the `Holiday` -- a `HolidayVersions` client type is added which follows the same style as `Holidays` 

This is a breaking change, but requires only minimal tweaks to usage:


Old Style:

```javascript
const c = new TourManager();

const h = await c.holidays.find(holidayId);
const v = await h.findVersion(vid);
```

New Style:

```javascript
const c = new TourManager();

const v = await c.holidays.versions(holidayId).find(versionId);
```